### PR TITLE
fix deprecation warning

### DIFF
--- a/src/JLD.jl
+++ b/src/JLD.jl
@@ -762,7 +762,7 @@ length(x::Union(JldFile, JldGroup)) = length(names(x))
 is_valid_type_ex(s::Symbol) = true
 is_valid_type_ex(s::QuoteNode) = true
 is_valid_type_ex{T}(::T) = isbits(T)
-is_valid_type_ex(e::Expr) = ((e.head == :curly || e.head == :tuple || e.head == :.) && all(map(is_valid_type_ex, e.args))) ||
+is_valid_type_ex(e::Expr) = ((e.head == :curly || e.head == :tuple || e.head == :.) && all(is_valid_type_ex, e.args)) ||
                             (e.head == :call && (e.args[1] == :Union || e.args[1] == :TypeVar))
 
 if VERSION >= v"0.4.0-dev+1419"


### PR DESCRIPTION
Tests pass on 0.3 for me. On 0.4, the unit tests hang on current master with and without this commit.

In my own code, this commit works, and silences the deprecation warning.

