### PR TITLE
readas, writeas, and translate for custom serialization & type-repair

### DIFF
--- a/test/custom_serialization.jl
+++ b/test/custom_serialization.jl
@@ -1,0 +1,78 @@
+module MyTypes
+
+import Base: ==
+export MyType, MyContainer
+
+## Objects we want to save
+# data in MyType is always of length 5, and that is the basis for a more efficient serialization
+immutable MyType{T}
+    data::Vector{T}
+    id::Int
+
+    function MyType(v::Vector{T}, id::Integer)
+        length(v) == 5 || error("All vectors must be of length 5")
+        new(v, id)
+    end
+end
+MyType{T}(v::Vector{T}, id::Integer) = MyType{T}(v, id)
+Base.eltype{T}(::Type{MyType{T}}) = T
+==(a::MyType, b::MyType) = a.data == b.data && a.id == b.id
+
+immutable MyContainer{T}
+    objs::Vector{MyType{T}}
+end
+Base.eltype{T}(::Type{MyContainer{T}}) = T
+==(a::MyContainer, b::MyContainer) = length(a.objs) == length(b.objs) && all(i->a.objs[i]==b.objs[i], 1:length(a.objs))
+
+end
+
+
+### Here are the definitions needed to implement the custom serialization
+# If you prefer, you could include these definitions in the MyTypes module
+module MySerializer
+
+using HDF5, JLD, MyTypes
+
+## Defining the serialization format
+type MyContainerSerializer{T}
+    data::Matrix{T}
+    ids::Vector{Int}
+end
+MyContainerSerializer{T}(data::Matrix{T},ids) = MyContainerSerializer{T}(data, ids)
+Base.eltype{T}(::Type{MyContainerSerializer{T}}) = T
+Base.eltype{T}(::MyContainerSerializer{T}) = T
+
+JLD.readas(serdata::MyContainerSerializer) =
+    MyContainer([MyType(serdata.data[:,i], serdata.ids[i]) for i = 1:length(serdata.ids)])
+function JLD.writeas{T}(data::MyContainer{T})
+    ids = [obj.id for obj in data.objs]
+    n = length(data.objs)
+    vectors = Array(T, 5, n)
+    for i = 1:n
+        vectors[:,i] = data.objs[i].data
+    end
+    MyContainerSerializer(vectors, ids)
+end
+
+end   # MySerializer
+
+
+
+using MyTypes, JLD, Base.Test
+
+obj1 = MyType(rand(5), 2)
+obj2 = MyType(rand(5), 17)
+container = MyContainer([obj1,obj2])
+filename = joinpath(tempdir(), "customserializer.jld")
+jldopen(filename, "w") do file
+    write(file, "mydata", container)
+end
+
+container_r = jldopen(filename) do file
+    obj = file["mydata"]
+    dtype = JLD.datatype(obj.plain)
+    @test JLD.jldatatype(JLD.file(obj), dtype) === MySerializer.MyContainerSerializer{Float64}
+    read(file, "mydata")
+end
+
+@test container_r == container

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,8 @@ runtest(filename) = (println(filename); include(filename))
 
 runtest("jldtests.jl")
 runtest("require.jl")
+runtest("custom_serialization.jl")
+runtest("type_translation.jl")
 if Pkg.installed("DataFrames") != nothing
     runtest("jld_dataframe.jl")
 end

--- a/test/type_translation.jl
+++ b/test/type_translation.jl
@@ -1,0 +1,55 @@
+module Translation
+
+const filename = joinpath(tempdir(), "translation.jld")
+
+module Writing
+
+using JLD
+import ..Translation: filename
+
+type MyType
+    a::Int
+end
+
+jldopen(filename, "w") do file
+    truncate_module_path(file, Writing)
+    write(file, "x", MyType(3))
+end
+
+end
+
+
+module Reading
+
+using JLD, Base.Test
+import ..Translation: filename
+
+type MyType
+    a::Int
+    b::Float32
+end
+
+type MyOldType
+    a::Int
+end
+
+translate("MyType", "MyOldType")
+
+t = jldopen(filename) do file
+    truncate_module_path(file, Reading)
+    read(file, "x")
+end
+
+@test isa(t, MyOldType)
+
+JLD.readas(x::MyOldType) = MyType(x.a, 0f0)
+
+t = jldopen(filename) do file
+    read(file, "x")
+end
+
+@test isa(t, MyType)
+
+end
+
+end


### PR DESCRIPTION
This is a revival of https://github.com/timholy/HDF5.jl/pull/191. To fix types that have changed between writing and the current code, it uses the following strategy:
1. The user defines a `MyOldType` that corresponds to the on-disk version
2. The user specifies that one should read an object whose *string* type is `MyType` as `MyOldType`
3. The user define a `readas` method to convert a `MyOldType` into `MyType`.
