### PR TITLE
Fix Travis error due to precompilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *~
 *.h5
 *.mat
+*.jl.*.cov
+*.jl.mem

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ script:
     - julia -e 'Pkg.clone(pwd()); Pkg.add("JLDArchives"); Pkg.checkout("JLDArchives")'
     - julia -e 'Pkg.test("JLD",coverage=true); Pkg.test("JLDArchives",coverage=true)'
 after_success:
-    - if [ $TRAVIS_JULIA_VERSION = "nightly" ]; then julia -e 'cd(Pkg.dir("JLD")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'; fi
+    - if [ $TRAVIS_JULIA_VERSION = "nightly" ]; then julia -e 'cd(Pkg.dir("JLD")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ notifications:
 script:
     - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
     - julia -e 'Pkg.clone(pwd()); Pkg.add("JLDArchives"); Pkg.checkout("JLDArchives")'
-    - if [ $TRAVIS_JULIA_VERSION = "nightly" ]; then julia --check-bounds=yes --inline=no --code-coverage=user -e 'reload("JLD/test/runtests.jl"); workspace(); import LastMain.Compat, LastMain.HDF5, LastMain.JLD; reload("JLD/src/JLD.jl"); reload("JLDArchives/test/runtests.jl")'; fi
-    - if [ $TRAVIS_JULIA_VERSION = "release" ]; then julia --check-bounds=yes -e 'Pkg.test("JLD"); Pkg.test("JLDArchives")'; fi
+    - julia -e 'Pkg.test("JLD",coverage=true); Pkg.test("JLDArchives",coverage=true)'
 after_success:
-    - if [ $TRAVIS_JULIA_VERSION = "nightly" ]; then julia -e 'cd(Pkg.dir("JLD")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'; fi
+    - if [ $TRAVIS_JULIA_VERSION = "nightly" ]; then julia -e 'cd(Pkg.dir("JLD")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'; fi

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://travis-ci.org/JuliaLang/JLD.jl.svg?branch=master)](https://travis-ci.org/JuliaLang/JLD.jl)
 [![Build status](https://ci.appveyor.com/api/projects/status/p2wkp87jfr0q7g4q?svg=true)](https://ci.appveyor.com/project/timholy/jld-jl)
+[![codecov.io](http://codecov.io/github/JuliaLang/JLD.jl/coverage.svg?branch=master)](http://codecov.io/github/JuliaLang/JLD.jl?branch=master)
 
 JLD, for which files conventionally have the extension `.jld`, is a
 widely-used format for data storage with the Julia programming


### PR DESCRIPTION
The shenanigans we used to pull with `workspace` now seem to be failing
due to precompilation. OTOH, now that we can merge Coverage counts
from multiple julia processes, we don't need those shenanigans anymore.

This also seems to fix a previously-undetected problem, that the
DataFrames test wasn't being run (test/REQUIRE doesn't get used if you're
not running with `Pkg.test`).

Hopefully fixes problems noted in #16. CC @amack315.