### PR TITLE
Hyperslab addition (`dset[indexes...] = x::Number`)

### DIFF
--- a/src/JLD.jl
+++ b/src/JLD.jl
@@ -704,6 +704,9 @@ end
         HDF5.h5s_close(dsel_id)
     end
 end
+@compat function setindex!(dset::JldDataset, x::Number, indices::Union{Range{Int},Integer}...)
+    setindex!(dset, fill(x, map(length, indices)), indices...)
+end
 
 @compat getindex(dset::JldDataset, I::Union{Range{Int},Integer,Colon}...) = getindex(dset, ntuple(i-> isa(I[i], Colon) ? (1:size(dset,i)) : I[i], length(I))...)
 @compat setindex!(dset::JldDataset, x, I::Union{Range{Int},Integer,Colon}...) = setindex!(dset, x, ntuple(i-> isa(I[i], Colon) ? (1:size(dset,i)) : I[i], length(I))...)

--- a/test/jldtests.jl
+++ b/test/jldtests.jl
@@ -365,6 +365,26 @@ write(fid, "a", [1:3;])
 close(fid)
 rm(fn)
 
+# Hyperslab
+for compress in (false, true)
+    jldopen(fn, "w") do fid
+        write(fid, "a", [1:3;])
+        aset = fid["a"]
+        aset[1:2] = [5,7]
+        b = read(fid, "a")
+        @test b == [5,7,3]
+        @test aset[2:3] == [7,3]
+        aset[3] = 27
+        @test aset[1:3] == [5,7,27]
+        Arnd = rand(5,3)
+        write(fid, "A", Arnd)
+        Aset = fid["A"]
+        Aset[:,2] = 15
+        Arnd[:,2] = 15
+        @test read(fid, "A") == Arnd
+    end
+end
+
 
 for compress in (true,false)
     fid = jldopen(fn, "w", compress=compress)


### PR DESCRIPTION
Fixes a former stack overflow (from the Colon translation calls).