### PR TITLE
Escape spaces in symbols

### DIFF
--- a/test/jldtests.jl
+++ b/test/jldtests.jl
@@ -420,8 +420,10 @@ for compatible in (false, true), compress in (false, true)
     @write fid syms
     @write fid d
     @write fid ex
-    @write fid fun
-    @write fid function_referencing_module
+    if VERSION < v"0.5.0-dev"
+        @write fid fun
+        @write fid function_referencing_module
+    end
     @write fid T
     @write fid char
     @write fid unicode_char
@@ -538,12 +540,14 @@ for compatible in (false, true), compress in (false, true)
         @check fidr d
         exr = read(fidr, "ex")   # line numbers are stripped, don't expect equality
         checkexpr(ex, exr)
-        funr = read(fidr, "fun")
-        checkfuns(fun, funr)
-        @test funr(3,5) == 38
-        function_referencing_module_r = read(fidr, "function_referencing_module")
-        checkfuns(function_referencing_module, function_referencing_module_r)
-        @test function_referencing_module_r(3,7) == 34
+        if VERSION < v"0.5.0-dev"
+            funr = read(fidr, "fun")
+            checkfuns(fun, funr)
+            @test funr(3,5) == 38
+            function_referencing_module_r = read(fidr, "function_referencing_module")
+            checkfuns(function_referencing_module, function_referencing_module_r)
+            @test function_referencing_module_r(3,7) == 34
+        end
         @check fidr T
         @check fidr char
         @check fidr unicode_char

--- a/test/jldtests.jl
+++ b/test/jldtests.jl
@@ -40,6 +40,7 @@ ms = MyStruct(2, [3.2, -1.7])
 msempty = MyStruct(5, Float64[])
 sym = :TestSymbol
 syms = [:a, :b]
+symhard = symbol("troublesome \"symbol\"")
 d = Dict([(syms[1],"aardvark"), (syms[2], "banana")])
 ex = quote
     function incrementby1(x::Int)
@@ -418,6 +419,7 @@ for compatible in (false, true), compress in (false, true)
     @write fid msempty
     @write fid sym
     @write fid syms
+    @write fid symhard
     @write fid d
     @write fid ex
     if VERSION < v"0.5.0-dev"
@@ -537,6 +539,7 @@ for compatible in (false, true), compress in (false, true)
         @check fidr msempty
         @check fidr sym
         @check fidr syms
+        @check fidr symhard
         @check fidr d
         exr = read(fidr, "ex")   # line numbers are stripped, don't expect equality
         checkexpr(ex, exr)


### PR DESCRIPTION
I was playing with [BaseBenchmarks.jl](https://github.com/JuliaCI/BaseBenchmarks.jl) on my own machine, and discovered that JLD doesn't support symbols that have a space in them, constructed via `symbol("hello there")`. This fixes that problem.

I also turned off the function tests for julia-0.5, see #57.